### PR TITLE
Fix order description on edit license template.

### DIFF
--- a/templates/admin/licenses/page-edit.php
+++ b/templates/admin/licenses/page-edit.php
@@ -105,7 +105,7 @@ if ( empty( $expiresAt ) || '0000-00-00 00:00:00' === $expiresAt ) {
 							}
 							?>
                         </select>
-                        <p class="description"><?php esc_html_e( 'The product to which the license keys will be assigned.', 'digital-license-manager' ); ?></p>
+                        <p class="description"><?php esc_html_e( 'The order to which the license keys will be assigned.', 'digital-license-manager' ); ?></p>
                     </td>
                 </tr>
 


### PR DESCRIPTION
@gdarko,
The order description on the edit license template was for the product description.