### PR TITLE
Display expiration date consistently.

### DIFF
--- a/includes/Abstracts/SettingsFieldsTrait.php
+++ b/includes/Abstracts/SettingsFieldsTrait.php
@@ -112,4 +112,41 @@ trait SettingsFieldsTrait {
         return ob_get_clean();
 	}
 
+	/**
+	 * Renders a text input field.
+	 *
+	 * @param array $args {
+	 *     Optional arguments.
+	 *
+	 *     @type string $explain A description of the setting.
+	 *     @type string $field   The setting identifier in the option group.
+	 *     @type string $key     The option group name.
+	 *     @type int    $size    The size, in characters, of the text field. Defaults to 20.
+	 *     @type string $value   The setting's value.
+	 * }
+	 */
+	public function fieldText( $args ) {
+
+		$args  = wp_parse_args(
+			$args,
+			array(
+				'explain' => '', // Should be HTML escaped.
+				'field'   => '',
+				'key'     => '',
+				'size'    => '20',
+				'value'   => '',
+			)
+		);
+		$html  = sprintf(
+			'<input type="text" id="%s" name="%s[%s]" value="%s" size="%s">',
+			$args['field'],
+			$args['key'],
+			$args['field'],
+			esc_attr( $args['value'] ),
+			$args['size']
+		);
+		$html .= "<p class='description'>{$args['explain']}</p>";
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $html;
+	}
 }

--- a/includes/Controllers/Settings.php
+++ b/includes/Controllers/Settings.php
@@ -385,7 +385,8 @@ class Settings extends Singleton {
 					$field_args          = isset( $field['args'] ) ? $field['args'] : array();
 					$field_args['key']   = $option_name;
 					$field_args['field'] = $field['id'];
-					$field_args['value'] = isset( $settings[ $slug ][ $field['id'] ] ) ? $settings[ $slug ][ $field['id'] ] : null;
+					$default             = $field['default'] ?? null;
+					$field_args['value'] = isset( $settings[ $slug ][ $field['id'] ] ) ? $settings[ $slug ][ $field['id'] ] : $default;
 					if ( ! is_null( $field_callback ) ) {
 						add_settings_field(
 							$field['id'],

--- a/includes/Controllers/Settings.php
+++ b/includes/Controllers/Settings.php
@@ -76,6 +76,7 @@ class Settings extends Singleton {
 									'explain' => __( 'If enabled the system will store new license keys in the database, even if the same key exist.', 'digital-license-manager' ),
 								)
 							),
+							50 => $this->getExpirationFormatField(),
 						)
 					),
 					'branding' => array(
@@ -124,7 +125,6 @@ class Settings extends Singleton {
 									'explain' => __( "If enabled your data will NOT be removed once this plugin is uninstalled. This is usually prefered option in case you want to use the plugin again in future.", 'digital-license-manager' ),
 								)
 							),
-							20 => $this->getExpirationFormatField(),
 						),
 					)
 				),
@@ -176,7 +176,7 @@ class Settings extends Singleton {
 
 		return array(
 			'id'       => 'expiration_format',
-			'title'    => __( 'Expiration format', 'digital-license-manager' ),
+			'title'    => __( 'License expiration format', 'digital-license-manager' ),
 			'callback' => array( $this, 'fieldText' ),
 			'args'     => array(
 				'explain'   => sprintf(

--- a/includes/Controllers/Settings.php
+++ b/includes/Controllers/Settings.php
@@ -181,7 +181,7 @@ class Settings extends Singleton {
 			'args'     => array(
 				'explain'   => sprintf(
 					/* translators: %1$s: date format merge code, %2$s: time format merge code, %3$s: general settings URL, %4$s: link to date and time formatting documentation */
-					__( '%1$s and %2$s will be replaced by formats from <a href="%3$s">Administration > Settings > General</a>. %4$s', 'digital-license-manager' ),
+					__( '<code>%1$s</code> and <code>%2$s</code> will be replaced by formats from <a href="%3$s">Administration > Settings > General</a>. %4$s', 'digital-license-manager' ),
 					'{{DATE_FORMAT}}',
 					'{{TIME_FORMAT}}',
 					esc_url( admin_url( 'options-general.php' ) ),

--- a/includes/Controllers/Settings.php
+++ b/includes/Controllers/Settings.php
@@ -123,7 +123,8 @@ class Settings extends Singleton {
 									'label'   => __( "Enable this option to safe guard the data on plugin removal/uninstallation.", 'digital-license-manager' ),
 									'explain' => __( "If enabled your data will NOT be removed once this plugin is uninstalled. This is usually prefered option in case you want to use the plugin again in future.", 'digital-license-manager' ),
 								)
-							)
+							),
+							20 => $this->getExpirationFormatField(),
 						),
 					)
 				),
@@ -164,6 +165,33 @@ class Settings extends Singleton {
 
 		return $tabList;
 
+	}
+
+	/**
+	 * Returns an array of setting field arguments for the expiration format.
+	 *
+	 * @return array
+	 */
+	protected function getExpirationFormatField() {
+
+		return array(
+			'id'       => 'expiration_format',
+			'title'    => __( 'Expiration format', 'digital-license-manager' ),
+			'callback' => array( $this, 'fieldText' ),
+			'args'     => array(
+				'explain'   => sprintf(
+					/* translators: %1$s: date format merge code, %2$s: time format merge code, %3$s: general settings URL, %4$s: link to date and time formatting documentation */
+					__( '%1$s and %2$s will be replaced by formats from <a href="%3$s">Administration > Settings > General</a>. %4$s', 'digital-license-manager' ),
+					'{{DATE_FORMAT}}',
+					'{{TIME_FORMAT}}',
+					esc_url( admin_url( 'options-general.php' ) ),
+					__( '<a href="https://wordpress.org/support/article/formatting-date-and-time/">Documentation on date and time formatting</a>.' ),
+				),
+				'label_for' => 'expiration_format',
+				'size'      => 40,
+			),
+			'default'  => '{{DATE_FORMAT}}, {{TIME_FORMAT}} T',
+		);
 	}
 
 	/**
@@ -410,6 +438,12 @@ class Settings extends Singleton {
 	 * @return array
 	 */
 	public function sanitizeGeneral( $settings ) {
+
+		// Ensure that the expiration format is not empty.
+		if ( empty( $settings['expiration_format'] ) ) {
+			$expiration_format_field       = $this->getExpirationFormatField();
+			$settings['expiration_format'] = $expiration_format_field['default'];
+		}
 
 		do_action( 'dlm_settings_sanitized', $settings );
 

--- a/includes/Integrations/WooCommerce/Certificates.php
+++ b/includes/Integrations/WooCommerce/Certificates.php
@@ -5,6 +5,7 @@ namespace IdeoLogix\DigitalLicenseManager\Integrations\WooCommerce;
 use IdeoLogix\DigitalLicenseManager\Database\Models\Resources\License;
 use IdeoLogix\DigitalLicenseManager\Settings;
 use IdeoLogix\DigitalLicenseManager\Utils\Data\License as LicenseUtil;
+use IdeoLogix\DigitalLicenseManager\Utils\DateFormatter;
 use Spipu\Html2Pdf\Exception\ExceptionFormatter;
 use Spipu\Html2Pdf\Exception\Html2PdfException;
 use Spipu\Html2Pdf\Html2Pdf;
@@ -118,6 +119,12 @@ class Certificates {
 		/**
 		 * Setup the license details
 		 */
+		$expiry_date = $license->getExpiresAt();
+		if ( empty( $expiry_date ) ) {
+			$expiry_date = __( 'Valid Permanently', 'digital-license-manager' );
+		} else {
+			$expiry_date = wp_date( DateFormatter::getExpirationFormat(), strtotime( $expiry_date ) );
+		}
 		$license_details = array(
 			array(
 				'title' => __( 'License ID', 'digital-license-manager' ),
@@ -129,7 +136,7 @@ class Certificates {
 			),
 			array(
 				'title' => __( 'Expiry Date', 'digital-license-manager' ),
-				'value' => empty( $license->getExpiresAt() ) ? __( 'Valid Permanently', 'digital-license-manager' ) : date_i18n( wc_date_format(), strtotime( $license->getExpiresAt() ) ),
+				'value' => $expiry_date,
 			)
 		);
 		if ( $customer ) {

--- a/includes/Integrations/WooCommerce/Orders.php
+++ b/includes/Integrations/WooCommerce/Orders.php
@@ -11,6 +11,7 @@ use IdeoLogix\DigitalLicenseManager\ListTables\Licenses;
 use IdeoLogix\DigitalLicenseManager\Settings;
 use IdeoLogix\DigitalLicenseManager\Utils\Data\Generator as GeneratorUtil;
 use IdeoLogix\DigitalLicenseManager\Utils\Data\License as LicenseUtil;
+use IdeoLogix\DigitalLicenseManager\Utils\DateFormatter;
 use WC_Order;
 use WC_Order_Item_Product;
 use WC_Product;
@@ -311,7 +312,7 @@ class Orders {
 				'heading'     => apply_filters( 'dlm_licenses_table_heading', __( 'Your digital license(s)', 'digital-license-manager' ) ),
 				'valid_until' => apply_filters( 'dlm_licenses_table_valid_until', __( 'Valid until', 'digital-license-manager' ) ),
 				'data'        => $customerLicenseKeys['data'],
-				'date_format' => get_option( 'date_format' ),
+				'date_format' => DateFormatter::getExpirationFormat(),
 				'args'        => apply_filters( 'dlm_template_args_myaccount_licenses', array() )
 			),
 			'',

--- a/includes/Utils/Data/License.php
+++ b/includes/Utils/Data/License.php
@@ -648,7 +648,11 @@ class License {
 		if ( $license->isExpired() ) {
 			return new WP_Error(
 				'license_expired',
-				sprintf( 'The license Key expired on %s (UTC).', $license->getExpiresAt() ),
+				sprintf(
+					/* translators: %s: expiration date */
+					__( 'The license key expired at %s.', 'digital-license-manager' ),
+					wp_date( DateFormatter::getExpirationFormat(), strtotime( $license->getExpiresAt() ) )
+				),
 				array( 'status' => 405 )
 			);
 		}

--- a/includes/Utils/DateFormatter.php
+++ b/includes/Utils/DateFormatter.php
@@ -4,6 +4,7 @@
 namespace IdeoLogix\DigitalLicenseManager\Utils;
 
 use DateTime;
+use IdeoLogix\DigitalLicenseManager\Settings;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -14,6 +15,15 @@ defined( 'ABSPATH' ) || exit;
  * @package IdeoLogix\DigitalLicenseManager\Utils
  */
 class DateFormatter {
+
+	/**
+	 * The expiration date and time format.
+	 *
+	 * @see https://www.php.net/manual/datetime.format.php
+	 *
+	 * @var string
+	 */
+	protected static $expiration_format;
 
 	/**
 	 * Converts valid_for into expires_at.
@@ -52,6 +62,36 @@ class DateFormatter {
 		$dt = \DateTime::createFromFormat( $srcFormat, $value );
 
 		return 'system' === $targetFormat ? $dt->format( get_option( 'date_format' ) ) : $dt->format( $targetFormat );
+	}
+
+	/**
+	 * Returns a format string for expiration dates.
+	 *
+	 * @return string
+	 */
+	public static function getExpirationFormat() {
+
+		if ( empty( self::$expiration_format ) ) {
+
+			$expiration_format = Settings::get( 'expiration_format' );
+			if ( false === $expiration_format ) {
+				$expiration_format = '{{DATE_FORMAT}}, {{TIME_FORMAT}} T';
+			}
+
+			if ( strpos( $expiration_format, '{{DATE_FORMAT}}' ) !== false ) {
+				$date_format       = get_option( 'date_format', 'F j, Y' );
+				$expiration_format = str_replace( '{{DATE_FORMAT}}', $date_format, $expiration_format );
+			}
+
+			if ( strpos( $expiration_format, '{{TIME_FORMAT}}' ) !== false ) {
+				$time_format       = get_option( 'time_format', 'g:i a' );
+				$expiration_format = str_replace( '{{TIME_FORMAT}}', $time_format, $expiration_format );
+			}
+
+			self::$expiration_format = $expiration_format;
+		}
+
+		return self::$expiration_format;
 	}
 
 	/**

--- a/includes/Utils/DateFormatter.php
+++ b/includes/Utils/DateFormatter.php
@@ -116,66 +116,47 @@ class DateFormatter {
 			$args['never'] = __( 'Never', 'digital-license-manager' );
 		}
 
-		static $dateFormat = null;
-		static $gmtOffset = null;
+		$timestampInput = strtotime( $date_str );
 
-		if ( ! $dateFormat ) {
-			$dateFormat = get_option( 'date_format' );
-		}
+		if ( $args['expires'] ) {
 
-		if ( ! $gmtOffset ) {
-			$gmtOffset = get_option( 'gmt_offset' );
-		}
+			if ( empty( $date_str ) || '0000-00-00 00:00:00' === $date_str ) {
+				return sprintf(
+					'<span class="dlm-date dlm-date-valid" title="%s">%s</span>%s',
+					$args['never'],
+					$args['never'],
+					$args['br'] ? '<br/>' : ''
+				);
 
-		try {
-
-			$offsetSeconds  = floatval( $gmtOffset ) * 60 * 60;
-			$timestampInput = strtotime( $date_str ) + $offsetSeconds;
-			$datetimeString = date( 'Y-m-d H:i:s', $timestampInput );
-			$dateInput      = new DateTime( $datetimeString );
-
-			if ( $args['expires'] ) {
-
-				if ( empty( $date_str ) || '0000-00-00 00:00:00' === $date_str ) {
+			} else {
+				$timestampNow = strtotime( 'now' );
+				if ( $timestampNow >= $timestampInput ) {
 					return sprintf(
-						'<span class="dlm-date dlm-date-valid" title="%s">%s</span>%s',
-						$args['never'],
-						$args['never'],
+						'<span class="dlm-date dlm-date-expired" title="%s">%s</span>%s',
+						__( 'Expired' ),
+						wp_date( DateFormatter::getExpirationFormat(), $timestampInput ),
 						$args['br'] ? '<br/>' : ''
 					);
-
 				} else {
-					$timestampNow = strtotime( 'now' ) + $offsetSeconds;
-					if ( $timestampNow >= $timestampInput ) {
-						return sprintf(
-							'<span class="dlm-date dlm-date-expired" title="%s">%s</span>%s',
-							__( 'Expired' ),
-							$dateInput->format( $dateFormat ),
-							$args['br'] ? '<br/>' : ''
-						);
-					} else {
 
-						$diffSeconds = $timestampInput - $timestampNow;
-						$statusClass = $diffSeconds > MONTH_IN_SECONDS ? 'dlm-date-valid' : 'dlm-date-expires-soon';
+					$diffSeconds = $timestampInput - $timestampNow;
+					$statusClass = $diffSeconds > MONTH_IN_SECONDS ? 'dlm-date-valid' : 'dlm-date-expires-soon';
 
-						return sprintf(
-							'<span class="dlm-date %s" title="%s">%s</span>%s',
-							$statusClass,
-							__( 'Active' ),
-							$dateInput->format( $dateFormat ),
-							$args['br'] ? '<br/>' : ''
-						);
-					}
+					return sprintf(
+						'<span class="dlm-date %s" title="%s">%s</span>%s',
+						$statusClass,
+						__( 'Active' ),
+						wp_date( DateFormatter::getExpirationFormat(), $timestampInput ),
+						$args['br'] ? '<br/>' : ''
+					);
 				}
 			}
-
-			return sprintf(
-				'<span class="dlm-date dlm-status">%s</span>',
-				$dateInput->format( $dateFormat ),
-			);
-		} catch ( \Exception $e ) {
-			return '';
 		}
+
+		return sprintf(
+			'<span class="dlm-date dlm-status">%s</span>',
+			wp_date( DateFormatter::getExpirationFormat(), $timestampInput ),
+		);
 	}
 
 }

--- a/templates/admin/licenses/page-add.php
+++ b/templates/admin/licenses/page-add.php
@@ -25,7 +25,7 @@
                     <th scope="row"><label for="single__expires_at"><?php esc_html_e('Expires at', 'digital-license-manager');?></label></th>
                     <td>
                         <input name="expires_at" id="single__expires_at" class="regular-text" type="text">
-                        <p class="description"><?php esc_html_e('The exact date this license key expires on. Leave blank if the license key does not expire. Cannot be used at the same time as the "Valid for (days)" field.', 'digital-license-manager');?></p>
+                        <p class="description"><?php esc_html_e('The exact date at midnight UTC that this license key expires on. Leave blank if the license key does not expire. Cannot be used at the same time as the "Valid for (days)" field.', 'digital-license-manager');?></p>
                     </td>
                 </tr>
 

--- a/templates/admin/licenses/page-edit.php
+++ b/templates/admin/licenses/page-edit.php
@@ -52,7 +52,7 @@ if ( empty( $expiresAt ) || '0000-00-00 00:00:00' === $expiresAt ) {
                     </th>
                     <td>
                         <input name="expires_at" id="edit__expires_at" class="regular-text" type="text" value="<?php echo esc_html( $expiresAt ); ?>">
-                        <p class="description"><?php esc_html_e( 'The exact date this license key expires on. Leave blank if the license key does not expire. Cannot be used at the same time as the "Valid for (days)" field.', 'digital-license-manager' ); ?></p>
+                        <p class="description"><?php esc_html_e( 'The exact date at midnight UTC that this license key expires on. Leave blank if the license key does not expire. Cannot be used at the same time as the "Valid for (days)" field.', 'digital-license-manager' ); ?></p>
                     </td>
                 </tr>
 

--- a/templates/woocommerce/dlm/emails/email-order-licenses.php
+++ b/templates/woocommerce/dlm/emails/email-order-licenses.php
@@ -27,7 +27,6 @@ defined( 'ABSPATH' ) || exit;
 <div style="margin-bottom: 40px;">
 	<?php foreach ( $data as $row ): ?>
         <table class="td" cellspacing="0" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
-            <tbody>
             <thead>
             <tr>
                 <th class="td" scope="col" style="text-align: left;" colspan="2">
@@ -35,6 +34,7 @@ defined( 'ABSPATH' ) || exit;
                 </th>
             </tr>
             </thead>
+			<tbody>
 			<?php
 			/** @var License $license */
 			foreach ( $row['keys'] as $license ):

--- a/templates/woocommerce/dlm/emails/email-order-licenses.php
+++ b/templates/woocommerce/dlm/emails/email-order-licenses.php
@@ -14,6 +14,7 @@
  */
 
 use IdeoLogix\DigitalLicenseManager\Database\Models\Resources\License;
+use IdeoLogix\DigitalLicenseManager\Utils\DateFormatter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -48,14 +49,11 @@ defined( 'ABSPATH' ) || exit;
                     </td>
 
 					<?php if ( $license->getExpiresAt() ): ?><?php
-						try {
-							$date = new DateTime( $license->getExpiresAt() );
-						} catch ( Exception $e ) {
-						}
+						$date = wp_date( DateFormatter::getExpirationFormat(), strtotime( $license->getExpiresAt() ) );
 						?>
                         <td class="td" style="text-align: left; vertical-align: middle; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;">
                             <code><?php
-								printf( '%s <strong>%s</strong>', $valid_until, $date->format( $date_format ) );
+								printf( '%s <strong>%s</strong>', $valid_until, $date );
 								?></code>
                         </td>
 					<?php endif; ?>

--- a/templates/woocommerce/dlm/my-account/orders/licenses.php
+++ b/templates/woocommerce/dlm/my-account/orders/licenses.php
@@ -22,7 +22,6 @@
  */
 
 use IdeoLogix\DigitalLicenseManager\Database\Models\Resources\License as LicenseResourceModel;
-use IdeoLogix\DigitalLicenseManager\Utils\DateFormatter;
 
 defined( 'ABSPATH' ) || exit; ?>
 
@@ -59,7 +58,7 @@ foreach ( $data as $productId => $row ): ?>
                 </td>
 				<?php if ( $license->getExpiresAt() ): ?>
 					<?php
-					$date = wp_date( DateFormatter::getExpirationFormat(), strtotime( $license->getExpiresAt() ) );
+					$date = wp_date( $date_format, strtotime( $license->getExpiresAt() ) );
 					?>
                     <td>
                         <span class="dlm-myaccount-license-key"><?php printf( '%s <strong>%s</strong>', $valid_until, $date ); ?></span>

--- a/templates/woocommerce/dlm/my-account/orders/licenses.php
+++ b/templates/woocommerce/dlm/my-account/orders/licenses.php
@@ -22,6 +22,7 @@
  */
 
 use IdeoLogix\DigitalLicenseManager\Database\Models\Resources\License as LicenseResourceModel;
+use IdeoLogix\DigitalLicenseManager\Utils\DateFormatter;
 
 defined( 'ABSPATH' ) || exit; ?>
 
@@ -58,14 +59,10 @@ foreach ( $data as $productId => $row ): ?>
                 </td>
 				<?php if ( $license->getExpiresAt() ): ?>
 					<?php
-					try {
-						$date = new DateTime( $license->getExpiresAt() );
-					} catch ( Exception $e ) {
-						$date = null;
-					}
+					$date = wp_date( DateFormatter::getExpirationFormat(), strtotime( $license->getExpiresAt() ) );
 					?>
                     <td>
-                        <span class="dlm-myaccount-license-key"><?php printf( '%s <strong>%s</strong>', $valid_until, $date ? $date->format( $date_format ) : 'N/A' ); ?></span>
+                        <span class="dlm-myaccount-license-key"><?php printf( '%s <strong>%s</strong>', $valid_until, $date ); ?></span>
                     </td>
 				<?php endif; ?>
                 <td class="license-key-actions">


### PR DESCRIPTION
* Added a function to `SettingsFieldsTrait` that renders text input fields.
* Added the ability to use a default setting field value.
* Added an `expiration_format` setting to the `dlm_settings_general` option.
  * Defaults to `{{DATE_FORMAT}}, {{TIME_FORMAT}} T`.
  * In the field description, added a link to the WordPress general settings page and a link to the WordPress date and time formatting documentation.
* The `{{DATE_FORMAT}}` and `{{TIME_FORMAT}}` merge codes are replaced with values from `get_option( 'date_format' )` and `get_option( 'time_format' )` respectively.
* Updated the following places to use `wp_date()` and `DateFormatter::getExpirationFormat()`:
  * certificate PDF
  * the bought licenses in the "My Account > Orders" page
  * the license expired error message when activating, deactivating, and reactivating
  * all calls to `DateFormatter::toHtml()`:
    * the "License Manager > Licenses" page
    * the "My Account > Licenses" page
    * the "My Account > Licenses > single" page
  * the licenses template that is added to the "order complete" email
* Updated the "Expires at" description in the "License Manager > Licenses > Add license" and "License Manager > Licenses > Edit license" pages to clarify the time of the day that the license expires.

Fixes #4.
