### PR TITLE
Add code and status to error when license key is not found.

### DIFF
--- a/includes/Utils/Data/License.php
+++ b/includes/Utils/Data/License.php
@@ -391,7 +391,14 @@ class License {
 		$license = LicenseResourceRepository::instance()->findBy( array( 'hash' => StringHasher::license( $licenseKey ) ) );
 
 		if ( ! $license ) {
-			return new WP_Error( sprintf( __( "The license key '%s' could not be found", 'digital-license-manager' ), $licenseKey ) );
+			return new WP_Error(
+				'data_error',
+				sprintf(
+					__( "The license key '%s' could not be found", 'digital-license-manager' ),
+					$licenseKey
+				),
+				array( 'status' => 404 )
+			);
 		}
 
 		if ( ! $licenseKey ) {


### PR DESCRIPTION
# Issue

When the `/wp-json/dlm/v1/licenses/activate` REST API endpoint can not find the license key, it returns a `WP_Error` object with the message as a code and without an HTTP status.

# Steps to reproduce

1. Use the `dlm-wp-updater` library to render an activation form.
2. Enter a license key that does not exist in the server.

# Expected response

"The license key 'imaginary-key' could not be found" is displayed as a WordPress error notice.

# Actual response

"Unable to decode response. (2)" is displayed as a WordPress error notice.

# Solution

This PR changes the WordPress error response to send a `data_error` code, the message as a message, and an HTTP status of 404 as extra data.
