### PR TITLE
fix several typos throughout the code

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -28,7 +28,7 @@
  * @note - DEVELOPER NOTE:
  *
  *     This file contains public functions that you can use in your code
- *     to interact with the Digital Licnese Manager database.
+ *     to interact with the Digital License Manager database.
  *
  *     The functions are mostly (with small changes) backwards compatible
  *     with "License Manager for WooCommerce".

--- a/i18n/languages/digital-license-manager.pot
+++ b/i18n/languages/digital-license-manager.pot
@@ -295,7 +295,7 @@ msgid ""
 msgstr ""
 
 #: templates/woocommerce/dlm/my-account/licenses/partials/table-activations-row-actions.php:56
-msgid "Are you sure you want to do this? This action can not be reversed."
+msgid "Are you sure you want to do this? This action can not be reverted."
 msgstr ""
 
 #: includes/Boot.php:425
@@ -308,7 +308,7 @@ msgid ""
 msgstr ""
 
 #: includes/Boot.php:314
-msgid "Are you sure? This action can not be reversed."
+msgid "Are you sure? This action can not be reverted."
 msgstr ""
 
 #: includes/Integrations/WooCommerce/Settings.php:47

--- a/i18n/languages/digital-license-manager.pot
+++ b/i18n/languages/digital-license-manager.pot
@@ -2246,6 +2246,10 @@ msgstr ""
 msgid "This document certifies the purchase of license key for: "
 msgstr ""
 
+#: templates/woocommerce/dlm/my-account/licenses/partials/single-certificate.php:44
+msgid "Details of the license can be accessed from your dashboard page."
+msgstr ""
+
 #: templates/admin/generators/page-edit.php:43
 msgid "This generator is assigned to the following product(s)"
 msgstr ""

--- a/i18n/languages/digital-license-manager.pot
+++ b/i18n/languages/digital-license-manager.pot
@@ -295,7 +295,7 @@ msgid ""
 msgstr ""
 
 #: templates/woocommerce/dlm/my-account/licenses/partials/table-activations-row-actions.php:56
-msgid "Are you sure you want to do this? This action can not be revered."
+msgid "Are you sure you want to do this? This action can not be reversed."
 msgstr ""
 
 #: includes/Boot.php:425
@@ -308,7 +308,7 @@ msgid ""
 msgstr ""
 
 #: includes/Boot.php:314
-msgid "Are you sure? This action can not be reverted."
+msgid "Are you sure? This action can not be reversed."
 msgstr ""
 
 #: includes/Integrations/WooCommerce/Settings.php:47
@@ -568,7 +568,7 @@ msgid "Disable"
 msgstr ""
 
 #: includes/Integrations/WooCommerce/Settings.php:91
-msgid "Disable Licnese"
+msgid "Disable License"
 msgstr ""
 
 #: includes/Enums/LicensePublicStatus.php:76

--- a/includes/Boot.php
+++ b/includes/Boot.php
@@ -311,7 +311,7 @@ class Boot {
 					'dropdownSearch' => wp_create_nonce( 'dlm_dropdown_search' )
 				),
 				'i18n'              => array(
-					'confirm_dialog'         => __( 'Are you sure? This action can not be reverted.', 'digital-license-manager' ),
+					'confirm_dialog'         => __( 'Are you sure? This action can not be reversed.', 'digital-license-manager' ),
 					'placeholderSearchUsers' => __( 'Search by user login, name or email', 'digital-license-manager' ),
 				)
 			)

--- a/includes/Boot.php
+++ b/includes/Boot.php
@@ -311,7 +311,7 @@ class Boot {
 					'dropdownSearch' => wp_create_nonce( 'dlm_dropdown_search' )
 				),
 				'i18n'              => array(
-					'confirm_dialog'         => __( 'Are you sure? This action can not be reversed.', 'digital-license-manager' ),
+					'confirm_dialog'         => __( 'Are you sure? This action can not be reverted.', 'digital-license-manager' ),
 					'placeholderSearchUsers' => __( 'Search by user login, name or email', 'digital-license-manager' ),
 				)
 			)

--- a/includes/Integrations/WooCommerce/Settings.php
+++ b/includes/Integrations/WooCommerce/Settings.php
@@ -88,7 +88,7 @@ class Settings {
 								'explain' => __( "Select what happens to the License once the line item that generated the License is refunded.", 'digital-license-manager' ),
 								'options' => [
 									'skip'    => __( 'Do Nothing', 'digital-license-manager' ),
-									'disable' => __( 'Disable Licnese', 'digital-license-manager' ),
+									'disable' => __( 'Disable License', 'digital-license-manager' ),
 									'delete'  => __( 'Delete License', 'digital-license-manager' ),
 								]
 							)

--- a/includes/Integrations/WooCommerce/Stock.php
+++ b/includes/Integrations/WooCommerce/Stock.php
@@ -251,9 +251,9 @@ class Stock {
 		}
 
 		$productId     = (int) $license->getProductId();
-		$licneseStatus = (int) $license->getStatus();
+		$licenseStatus = (int) $license->getStatus();
 
-		if ( ! empty( $productId ) && $licneseStatus === LicensePrivateStatus::ACTIVE ) {
+		if ( ! empty( $productId ) && $licenseStatus === LicensePrivateStatus::ACTIVE ) {
 			self::syncrhonizeProductStock( $productId );
 		}
 	}

--- a/includes/Integrations/WooCommerce/Tools/GeneratePastOrderLicenses/GeneratePastOrderLicenses.php
+++ b/includes/Integrations/WooCommerce/Tools/GeneratePastOrderLicenses/GeneratePastOrderLicenses.php
@@ -44,7 +44,7 @@ class GeneratePastOrderLicenses extends AbstractTool {
 	 * The description
 	 * @var string
 	 */
-	protected $description = 'Generate Licneses For Past Orders';
+	protected $description = 'Generate Licenses For Past Orders';
 
 	/**
 	 * Returns the view

--- a/readme.txt
+++ b/readme.txt
@@ -176,9 +176,9 @@ To deactivate a license through the REST API, please follow this <a href="http:/
 
 To validate a license through the REST API, please follow this <a href="http://docs.codeverve.com/digital-license-manager/rest-api/licenses/validate/" target="_blank">guide</a>.
 
-= Can I assign license keys to past WooCommerce orders that were placed before i installed Digital Licnese Manager?
+= Can I assign license keys to past WooCommerce orders that were placed before i installed Digital License Manager?
 
-Yes, you can do this by going to Settings > Tools > "Generate Licneses For Past Orders". You must select a Generator that will be used to generate keys for the orders.
+Yes, you can do this by going to Settings > Tools > "Generate Licenses For Past Orders". You must select a Generator that will be used to generate keys for the orders.
 
 == Screenshots ==
 

--- a/templates/woocommerce/dlm/my-account/licenses/partials/single-certificate.php
+++ b/templates/woocommerce/dlm/my-account/licenses/partials/single-certificate.php
@@ -41,7 +41,7 @@
             <strong><?php echo esc_html( wp_strip_all_tags( $license_product_name ) ); ?></strong>
         </p>
         <p style="font-size: 16px; margin-bottom: 20px; margin-top:0;">
-			<?php esc_html_e( 'Details of the license can be accessed from your dashboard page.', 'digital-license-manger' ); ?>
+			<?php esc_html_e( 'Details of the license can be accessed from your dashboard page.', 'digital-license-manager' ); ?>
         </p>
 		<?php if ( ! empty( $license_details ) ): ?>
             <table style="margin-top:0; margin-bottom: 20px;font-size: 16px; border-spacing: 15px; border: 1px solid #aaaaaa; border-collapse: collapse; width: 100%;">

--- a/templates/woocommerce/dlm/my-account/licenses/partials/table-activations-row-actions.php
+++ b/templates/woocommerce/dlm/my-account/licenses/partials/table-activations-row-actions.php
@@ -53,7 +53,7 @@ use IdeoLogix\DigitalLicenseManager\Database\Models\LicenseActivation;
 		<?php else: ?>
             <button type="submit"
 				<?php if ( isset( $rowAction['confirm'] ) && $rowAction['confirm'] ): ?>
-                    onclick="return confirm('<?php esc_html_e( 'Are you sure you want to do this? This action can not be revered.', 'digital-license-manager' ); ?>')"
+                    onclick="return confirm('<?php esc_html_e( 'Are you sure you want to do this? This action can not be reversed.', 'digital-license-manager' ); ?>')"
 				<?php endif; ?>
                     name="<?php echo esc_attr( $rowAction['id'] ); ?>"
                     title="<?php echo isset( $params['title'] ) ? esc_attr( $params['title'] ) : ''; ?>"

--- a/templates/woocommerce/dlm/my-account/licenses/partials/table-activations-row-actions.php
+++ b/templates/woocommerce/dlm/my-account/licenses/partials/table-activations-row-actions.php
@@ -53,7 +53,7 @@ use IdeoLogix\DigitalLicenseManager\Database\Models\LicenseActivation;
 		<?php else: ?>
             <button type="submit"
 				<?php if ( isset( $rowAction['confirm'] ) && $rowAction['confirm'] ): ?>
-                    onclick="return confirm('<?php esc_html_e( 'Are you sure you want to do this? This action can not be reversed.', 'digital-license-manager' ); ?>')"
+                    onclick="return confirm('<?php esc_html_e( 'Are you sure you want to do this? This action can not be reverted.', 'digital-license-manager' ); ?>')"
 				<?php endif; ?>
                     name="<?php echo esc_attr( $rowAction['id'] ); ?>"
                     title="<?php echo isset( $params['title'] ) ? esc_attr( $params['title'] ) : ''; ?>"


### PR DESCRIPTION
This PR fixes several typos in the code. Some are cosmetical, but the namespace typo `'digital-license-manger'` caused translations to not correctly work.