### PR TITLE
Fix missing plugin text domain in translatable strings.

### DIFF
--- a/includes/Controllers/Admin.php
+++ b/includes/Controllers/Admin.php
@@ -423,7 +423,7 @@ class Admin {
 				'<a href="https://wordpress.org/support/plugin/digital-license-manager/reviews/?rate=5#new-post" target="_blank" class="wc-rating-link" data-rated="' . esc_attr__( 'Thanks :)', 'digital-license-manager' ) . '">&#9733;&#9733;&#9733;&#9733;&#9733;</a>'
 			);
 			if ( ! defined( 'DLM_PRO_VERSION' ) ) {
-				$footerText .= '<br/>Need more functionality? Check <a style="font-weight:bold;color:#3eb03e;" target="_blank" href="' . DLM_PURCHASE_URL . '"><strong>' . __( 'Digital License Manager PRO', 'wp-vimeo-videos' ) . '</strong></a>';
+				$footerText .= '<br/>Need more functionality? Check <a style="font-weight:bold;color:#3eb03e;" target="_blank" href="' . DLM_PURCHASE_URL . '"><strong>' . __( 'Digital License Manager PRO', 'digital-license-manager' ) . '</strong></a>';
 			}
 		}
 

--- a/includes/Controllers/Settings.php
+++ b/includes/Controllers/Settings.php
@@ -228,7 +228,7 @@ class Settings {
 					'{{DATE_FORMAT}}',
 					'{{TIME_FORMAT}}',
 					esc_url( admin_url( 'options-general.php' ) ),
-					__( '<a href="https://wordpress.org/support/article/formatting-date-and-time/">Documentation on date and time formatting</a>.' )
+					__( '<a href="https://wordpress.org/support/article/formatting-date-and-time/">Documentation on date and time formatting</a>.', 'digital-license-manager' )
 				),
 				'label_for' => 'expiration_format',
 				'size'      => 40,
@@ -574,7 +574,7 @@ class Settings {
 	public function handleToolProcess() {
 
 		if ( ! check_ajax_referer( 'dlm-tools', '_wpnonce', false ) || ! current_user_can( 'dlm_manage_settings' ) ) {
-			wp_send_json_error( [ 'message' => __( 'Permission denied.' ) ] );
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'digital-license-manager' ) ] );
 			exit;
 		} else {
 
@@ -583,7 +583,7 @@ class Settings {
 			$tool_slug = isset( $_POST['tool'] ) ? sanitize_text_field( wp_unslash( $_POST['tool'] ) ) : null;
 			$tool_id   = isset( $_POST['id'] ) ? sanitize_text_field( wp_unslash( $_POST['id'] ) ) : null;
 			if ( is_null( $tool_slug ) || ! isset( $this->tools[ $tool_slug ] ) ) {
-				wp_send_json_error( [ 'message' => __( 'Unknown tool selected.' ) ] );
+				wp_send_json_error( [ 'message' => __( 'Unknown tool selected.', 'digital-license-manager' ) ] );
 				exit;
 			}
 
@@ -638,7 +638,7 @@ class Settings {
 	 */
 	public function handleToolStatus() {
 		if ( ! check_ajax_referer( 'dlm-tools', '_wpnonce', false ) || ! current_user_can( 'dlm_manage_settings' ) ) {
-			wp_send_json_error( [ 'message' => __( 'Permission denied.' ) ] );
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'digital-license-manager' ) ] );
 			exit;
 		} else {
 
@@ -661,7 +661,7 @@ class Settings {
 	 */
 	public function handleToolUndo() {
 		if ( ! check_ajax_referer( 'dlm-tools', '_wpnonce', false ) || ! current_user_can( 'dlm_manage_settings' ) ) {
-			wp_send_json_error( [ 'message' => __( 'Permission denied.' ) ] );
+			wp_send_json_error( [ 'message' => __( 'Permission denied.', 'digital-license-manager' ) ] );
 			exit;
 		} else {
 			$this->loadTools();
@@ -673,7 +673,7 @@ class Settings {
 				delete_option( 'nc_info_dlm_lmfwc' );
 				wp_send_json_success();
 			} else {
-				wp_send_json_error( [ 'message' => __( 'Operation Error.' ) ] );
+				wp_send_json_error( [ 'message' => __( 'Operation Error.', 'digital-license-manager' ) ] );
 			}
 			exit;
 		}

--- a/includes/Core/Services/LicensesService.php
+++ b/includes/Core/Services/LicensesService.php
@@ -256,7 +256,7 @@ class LicensesService implements ServiceInterface, MetadataInterface {
 	public function createMultiple( $keys, $params ) {
 
 		if ( ! is_array( $keys ) || empty( $keys ) ) {
-			return new WP_Error( 'data_error', __( 'No keys provided.' ) );
+			return new WP_Error( 'data_error', __( 'No keys provided.', 'digital-license-manager' ) );
 		}
 
 		$keys      = array_map( 'sanitize_text_field', $keys );
@@ -276,12 +276,12 @@ class LicensesService implements ServiceInterface, MetadataInterface {
 
 		// Validate status
 		if ( is_null( $status ) ) {
-			return new WP_Error( 'data_error', __( 'No valid status provided.' ) );
+			return new WP_Error( 'data_error', __( 'No valid status provided.', 'digital-license-manager' ) );
 		}
 
 		// Validate source
 		if ( is_null( $source ) ) {
-			return new WP_Error( 'data_error', __( 'No valid source provided.' ) );
+			return new WP_Error( 'data_error', __( 'No valid source provided.', 'digital-license-manager' ) );
 		}
 
 		// Filter for dups

--- a/includes/Integrations/WooCommerce/Commands/AddOrderItemLicenses.php
+++ b/includes/Integrations/WooCommerce/Commands/AddOrderItemLicenses.php
@@ -61,7 +61,7 @@ class AddOrderItemLicenses extends AbstractCommand {
 			$query = wc_get_orders( $this->get_args( $currPage ) );
 
 			if ( null === $progressBar ) {
-				$progressBar = \WP_CLI\Utils\make_progress_bar( __( 'Processing orders' ), $query->total );
+				$progressBar = \WP_CLI\Utils\make_progress_bar( __( 'Processing orders', 'digital-license-manager' ), $query->total );
 			}
 
 			foreach ( $query->orders as $i => $order ) {

--- a/includes/Integrations/WooCommerce/Orders.php
+++ b/includes/Integrations/WooCommerce/Orders.php
@@ -281,7 +281,7 @@ class Orders {
 				}
 
 			} else {
-				$log_msg = sprintf( __( 'License delivery failed: Could not find enough licenses in stock (Current stock: %d | Required %d).' ), $availableStock, $neededAmount );
+				$log_msg = sprintf( __( 'License delivery failed: Could not find enough licenses in stock (Current stock: %d | Required %d).', 'digital-license-manager' ), $availableStock, $neededAmount );
 			}
 
 			$order->add_order_note( $log_msg );

--- a/includes/Integrations/WooCommerce/Tools/AddOrderItemLicenses/AddOrderItemLicenses.php
+++ b/includes/Integrations/WooCommerce/Tools/AddOrderItemLicenses/AddOrderItemLicenses.php
@@ -107,7 +107,7 @@ class AddOrderItemLicenses extends AbstractTool {
 
 				$results = wc_get_orders( $query );
 				if ( empty( $results->orders ) ) {
-					return new \WP_Error( 'not_found', sprintf( __( 'No orders found for step "%s", page "%s"' ), $step, $page ) );
+					return new \WP_Error( 'not_found', sprintf( __( 'No orders found for step "%s", page "%s"', 'digital-license-manager' ), $step, $page ) );
 				}
 
 				$orderService = new OrdersService();

--- a/includes/Integrations/WooCommerce/Tools/GeneratePastOrderLicenses/GeneratePastOrderLicenses.php
+++ b/includes/Integrations/WooCommerce/Tools/GeneratePastOrderLicenses/GeneratePastOrderLicenses.php
@@ -138,7 +138,7 @@ class GeneratePastOrderLicenses extends AbstractTool {
 
 				$results = wc_get_orders( $query );
 				if ( empty( $results->orders ) ) {
-					return new \WP_Error( 'not_found', sprintf( __( 'No orders found for step "%s", page "%s"' ), $step, $page ) );
+					return new \WP_Error( 'not_found', sprintf( __( 'No orders found for step "%s", page "%s"', 'digital-license-manager' ), $step, $page ) );
 				}
 				$generatorId    = isset( $_POST['generator'] ) ? intval( $_POST['generator'] ) : 0;
 				$useProductConf = isset( $_POST['use_product_licensing_configuration'] ) ? intval( $_POST['use_product_licensing_configuration'] ) : 0;
@@ -230,7 +230,7 @@ class GeneratePastOrderLicenses extends AbstractTool {
 				if ( empty( $results->orders ) ) {
 					$this->deleteTemporaryData();
 
-					return new \WP_Error( 'not_found', sprintf( __( 'No orders found for step "%s", page "%s"' ), $step, $page ) );
+					return new \WP_Error( 'not_found', sprintf( __( 'No orders found for step "%s", page "%s"', 'digital-license-manager' ), $step, $page ) );
 				}
 
 				foreach ( $results->orders as $order ) {

--- a/templates/admin/licenses/modals/export.php
+++ b/templates/admin/licenses/modals/export.php
@@ -44,7 +44,7 @@ $columns = \IdeoLogix\DigitalLicenseManager\Controllers\Licenses::exportColumns(
                 </header>
                 <main class="modal__content" id="<?php echo esc_attr($modal_id); ?>-content">
                     <div class="dlm-form-row">
-                        <label><?php esc_html_e( 'Columns' ); ?></label>
+                        <label><?php esc_html_e( 'Columns', 'digital-license-manager' ); ?></label>
 						<?php foreach ( $columns as $column ): ?>
                             <p class="dlm-checkbox-row">
                                 <label>


### PR DESCRIPTION
Several user-facing strings omitted the digital-license-manager text domain, so translations from language packs were never loaded at runtime.